### PR TITLE
Pin sea-query-binder version

### DIFF
--- a/rusty-backend/Cargo.toml
+++ b/rusty-backend/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 url = {version = "2.5.0", features = ["serde"]}
 sea-query={ version = "0.30.7", features = ["derive", "attr", "backend-postgres", "with-json", "with-uuid"]}
 modql={ version = "0.3.10", features = ["with-sea-query"]}
-sea-query-binder = { version = "0", features = [
+sea-query-binder = { version = "0.5.0", features = [
     "sqlx-postgres",
     "with-json",
     "with-uuid"


### PR DESCRIPTION
This PR pins [sea-query-binder](https://crates.io/crates/sea-query-binder/versions) to v0.5.0

This should also fix #1 